### PR TITLE
docs(changelog): add v0.36.0 release entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-04-16
+
 ### Added
 - Compile-time dependency injection support via the `di` package and the `alya-di` generator
 - Config loader, provider, and watch support in `config`


### PR DESCRIPTION
## Summary

This PR adds the `0.36.0` release entry to `CHANGELOG.md`.

## Notes

This is a release-only changelog update after the main changes were merged.
The `v0.36.0` tag can be created after this PR merges.
